### PR TITLE
Keep dots present instead of fading and re-appearing again after anim…

### DIFF
--- a/apps/website/src/components/LifecycleAnimation.tsx
+++ b/apps/website/src/components/LifecycleAnimation.tsx
@@ -21,6 +21,7 @@ export default function LifecycleAnimation({ onFlyStart, onComplete }: Lifecycle
     if (!svg) return;
 
     const scene = q<SVGGElement>("#scene");
+    const stageElements = q<SVGGElement>("#stage-elements");
     const dots = qa<SVGGElement>("#dots .dot");
     const bodies = dots.map(
       (g) => g.querySelector(".bd") as SVGCircleElement,
@@ -41,6 +42,7 @@ export default function LifecycleAnimation({ onFlyStart, onComplete }: Lifecycle
 
     if (
       !scene ||
+      !stageElements ||
       dots.length !== 5 ||
       bodies.some((b) => !b) ||
       !track ||
@@ -485,7 +487,7 @@ export default function LifecycleAnimation({ onFlyStart, onComplete }: Lifecycle
         bodies[i].setAttribute("fill", dotColor(lit));
       }
 
-      scene.style.opacity = (1 - seg(t, T.holdEnd, T.fadeEnd)).toFixed(3);
+      stageElements.style.opacity = (1 - seg(t, T.holdEnd, T.fadeEnd)).toFixed(3);
 
       const ph = phaseAt(t);
       setCaption(ph.name, ph.line);
@@ -549,8 +551,8 @@ export default function LifecycleAnimation({ onFlyStart, onComplete }: Lifecycle
       const svgRect = svg.getBoundingClientRect();
       const unitX = 820 / svgRect.width;
 
-      // Reveal only the dots for the flight
-      scene.style.opacity = "1";
+      // Hide the remaining stage elements so only the dots fly
+      stageElements.style.opacity = "0";
       score.style.opacity = "0";
       head.style.opacity = "0";
       guide.style.opacity = "0";
@@ -595,13 +597,6 @@ export default function LifecycleAnimation({ onFlyStart, onComplete }: Lifecycle
 
       cleanupTimer = window.setTimeout(() => {
         onComplete?.();
-        dots.forEach((dot) => {
-          dot.animate([{ opacity: 1 }, { opacity: 0 }], {
-            duration: 200,
-            easing: "ease-in",
-            fill: "forwards",
-          });
-        });
       }, 900);
     }
 
@@ -657,60 +652,62 @@ export default function LifecycleAnimation({ onFlyStart, onComplete }: Lifecycle
         aria-label="Animated loop showing a reasoning kit assembling from five dots into a row, executing by passing a document through each step, moving into a gauge that is scored, and improving from 74 to 94."
       >
         <g id="scene">
-          <line
-            id="track"
-            x1="70"
-            y1="205"
-            x2="750"
-            y2="205"
-            stroke="#E4E3FB"
-            strokeWidth="3"
-            strokeLinecap="round"
-          />
-          <circle id="ring-guide" cx="410" cy="210" r="172" />
-          <circle
-            id="gauge"
-            cx="410"
-            cy="210"
-            r="172"
-            pathLength="100"
-            stroke="#716EEB"
-            strokeDasharray="100 100"
-            strokeDashoffset="100"
-          />
-          <circle
-            id="delta"
-            cx="410"
-            cy="210"
-            r="172"
-            pathLength="100"
-            strokeDasharray="100 100"
-            strokeDashoffset="100"
-          />
-          <circle id="edit-pulse" cx="410" cy="210" r="172" pathLength="100" />
-          <circle
-            id="sweep"
-            cx="410"
-            cy="210"
-            r="172"
-            pathLength="100"
-            stroke="#130DDD"
-            strokeDasharray="100 100"
-            strokeDashoffset="100"
-          />
-          <text id="score" x="410" y="246" fill="#111418">
-            94
-          </text>
-          <g id="ghost2">
-            <rect x="-15" y="-11" width="30" height="22" rx="6" />
+          <g id="stage-elements">
+            <line
+              id="track"
+              x1="70"
+              y1="205"
+              x2="750"
+              y2="205"
+              stroke="#E4E3FB"
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+            <circle id="ring-guide" cx="410" cy="210" r="172" />
+            <circle
+              id="gauge"
+              cx="410"
+              cy="210"
+              r="172"
+              pathLength="100"
+              stroke="#716EEB"
+              strokeDasharray="100 100"
+              strokeDashoffset="100"
+            />
+            <circle
+              id="delta"
+              cx="410"
+              cy="210"
+              r="172"
+              pathLength="100"
+              strokeDasharray="100 100"
+              strokeDashoffset="100"
+            />
+            <circle id="edit-pulse" cx="410" cy="210" r="172" pathLength="100" />
+            <circle
+              id="sweep"
+              cx="410"
+              cy="210"
+              r="172"
+              pathLength="100"
+              stroke="#130DDD"
+              strokeDasharray="100 100"
+              strokeDashoffset="100"
+            />
+            <text id="score" x="410" y="246" fill="#111418">
+              94
+            </text>
+            <g id="ghost2">
+              <rect x="-15" y="-11" width="30" height="22" rx="6" />
+            </g>
+            <g id="ghost1">
+              <rect x="-15" y="-11" width="30" height="22" rx="6" />
+            </g>
+            <g id="packetG">
+              <rect id="packet" x="-15" y="-11" width="30" height="22" rx="6" />
+            </g>
+            <circle id="head" r="5.5" stroke="#716EEB" strokeWidth="3" />
           </g>
-          <g id="ghost1">
-            <rect x="-15" y="-11" width="30" height="22" rx="6" />
-          </g>
-          <g id="packetG">
-            <rect id="packet" x="-15" y="-11" width="30" height="22" rx="6" />
-          </g>
-          <circle id="head" r="5.5" stroke="#716EEB" strokeWidth="3" />
           <g id="dots">
             <g className="dot">
               <circle className="sh" cy="5" r="29" />


### PR DESCRIPTION
…ation
This pull request refactors the `LifecycleAnimation` component to separate the stage elements from the rest of the SVG scene, improving control over their visibility and animation flow. The main change is the introduction of a new `stage-elements` group, which allows for more precise opacity management during animation phases, especially when isolating the flying dots effect.

**SVG structure and opacity management improvements:**

* Introduced a new `<g id="stage-elements">` group within the SVG, wrapping all stage-related elements except the dots, enabling independent control of their visibility. [[1]](diffhunk://#diff-bd2c513e14ac09888a73912bec02b0caa4581ed0f3bec8c3aa2801107e0bfeb7R655) [[2]](diffhunk://#diff-bd2c513e14ac09888a73912bec02b0caa4581ed0f3bec8c3aa2801107e0bfeb7R710)
* Updated all logic that previously referenced `scene` for opacity changes to now use `stageElements`, ensuring only stage elements fade out while dots remain visible during transitions. [[1]](diffhunk://#diff-bd2c513e14ac09888a73912bec02b0caa4581ed0f3bec8c3aa2801107e0bfeb7R24) [[2]](diffhunk://#diff-bd2c513e14ac09888a73912bec02b0caa4581ed0f3bec8c3aa2801107e0bfeb7R45) [[3]](diffhunk://#diff-bd2c513e14ac09888a73912bec02b0caa4581ed0f3bec8c3aa2801107e0bfeb7L488-R490) [[4]](diffhunk://#diff-bd2c513e14ac09888a73912bec02b0caa4581ed0f3bec8c3aa2801107e0bfeb7L552-R555)

**Animation cleanup:**

* Removed the final animation that faded out the dots after completion, so the dots remain visible until the animation fully completes.
